### PR TITLE
Refactor Room's page state

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,6 +5,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
+		<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital@0;1&display=swap" rel="stylesheet">
+
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/client/src/Player.elm
+++ b/client/src/Player.elm
@@ -1,0 +1,106 @@
+module Player exposing (..)
+
+import Json.Decode as D
+import Json.Encode as E
+
+
+type State
+    = Unstarted
+    | Ended
+    | Playing
+    | Paused
+    | Buffering
+    | VideoCued
+    | Unknown
+
+
+type Msg
+    = Play
+    | Pause
+    | LoadVideo String Float
+    | GetCurrentTime
+
+
+playerStateFromString : String -> State
+playerStateFromString stateString =
+    case stateString of
+        "Unstarted" ->
+            Unstarted
+
+        "Ended" ->
+            Ended
+
+        "Playing" ->
+            Playing
+
+        "Paused" ->
+            Paused
+
+        "Buffering" ->
+            Buffering
+
+        "VideoCued" ->
+            VideoCued
+
+        _ ->
+            Unknown
+
+
+stringFromPlayerState : State -> String
+stringFromPlayerState playerState =
+    case playerState of
+        Unstarted ->
+            "Unstarted"
+
+        Ended ->
+            "Ended"
+
+        Playing ->
+            "Playing"
+
+        Paused ->
+            "Paused"
+
+        Buffering ->
+            "Buffering"
+
+        VideoCued ->
+            "VideoCued"
+
+        Unknown ->
+            "Unknown"
+
+
+playMsgToString : Msg -> String
+playMsgToString msg =
+    case msg of
+        Play ->
+            "play"
+
+        Pause ->
+            "pause"
+
+        LoadVideo _ _ ->
+            "loadVideo"
+
+        GetCurrentTime ->
+            "getCurrentTime"
+
+
+encodePlayerMsg : Msg -> E.Value
+encodePlayerMsg playerMsg =
+    case playerMsg of
+        Play ->
+            E.object [ ( "message", E.string "play" ) ]
+
+        Pause ->
+            E.object [ ( "message", E.string "pause" ) ]
+
+        GetCurrentTime ->
+            E.object [ ( "message", E.string "getCurrentTime" ) ]
+
+        LoadVideo videoID time ->
+            E.object
+                [ ( "message", E.string "loadVideo" )
+                , ( "data", E.object [ ( "videoID", E.string videoID ), ( "time", E.float time ) ] )
+                ]

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -17,7 +17,6 @@ serviceWorker.unregister();
 var socket = io('localhost:3000');
 
 app.ports.sendData.subscribe(function(message) {
-  console.log('sendData', message);
   socket.emit('sendData', message);
 });
 
@@ -26,10 +25,12 @@ app.ports.joinRoom.subscribe(function (roomID) {
 });
 
 socket.on('syncData', function(msg){
-  console.log('received', msg);
   app.ports.dataReceiver.send(msg);
 });
 
+socket.on('joinedRoom', function(data) {
+  app.ports.joinedRoom.send(data);
+});
 
 let player = null;
 
@@ -52,7 +53,14 @@ app.ports.emitPlayerMsg.subscribe( ({message, data}) =>  {
 
       break;
     case 'loadVideo':
-      player.cueVideoById(data);
+      console.log('loadVideo', data);
+      player.cueVideoById(data.videoID, data.time)
+
+      break;
+    case 'getCurrentTime':
+      player.getCurrentTime().then(function(time) {
+        app.ports.playerCurrentTimeReceiver.send(time || 0.0);
+      });
 
       break;
     default:

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -10,7 +10,7 @@
 }
 
 * {
-  font-family: "Playfair Display script=latin rev=1";
+	font-family: 'Playfair Display', serif;
 	font-weight: 400;
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,13 +6,14 @@ io.on('connection', function(socket) {
     socket.join(roomID, () => {
       let rooms = Object.keys(socket.rooms);
 
-      socket.broadcast.to(roomID).emit('connection');
+      socket.emit('joinedRoom', io.sockets.adapter.rooms[roomID].length);
+
       console.log(rooms);
     });
   });
 
   socket.on('sendData', function (data) {
-    socket.broadcast.to(data.roomID).emit('syncData', data );
+    socket.broadcast.to(data.roomID).emit('syncData', data);
   });
 });
 


### PR DESCRIPTION
This commit completely rewrites the Room module to split the model from
the page itself from the room data that will be shared.

Also this models a state machine by introducing the page's states
(reflected on the `Room.Model`).

This way we can have more control on when and how we deal with certain
events / states.

The pattern I'm following on the `update` function is something like

(CurrentState, Msg)

So it replicate what a state machine would do.

The code still a little bit messy, a clean up will happen after the
first version is up


closes #8

Also sneaked some layout changes in there just for fun, no harm done