### PR TITLE
Use video URL instead of video ID on the interface

### DIFF
--- a/client/src/Player.elm
+++ b/client/src/Player.elm
@@ -2,6 +2,7 @@ module Player exposing (..)
 
 import Json.Decode as D
 import Json.Encode as E
+import Regex
 
 
 type State
@@ -114,3 +115,15 @@ encodePlayerMsg playerMsg =
                 [ ( "message", E.string "cueVideo" )
                 , ( "data", E.object [ ( "videoID", E.string videoID ), ( "time", E.float time ) ] )
                 ]
+
+
+youtubeIdFromUrl : String -> Maybe String
+youtubeIdFromUrl url =
+    List.head (Regex.find youtubeIdRegex url)
+        |> Maybe.andThen (.submatches >> List.filterMap identity >> List.head)
+
+
+youtubeIdRegex : Regex.Regex
+youtubeIdRegex =
+    Maybe.withDefault Regex.never <|
+        Regex.fromString "(?:youtube(?:-nocookie)?\\.com\\/(?:[^\\/\\n\\s]+\\/\\S+\\/|(?:v|e(?:mbed)?)\\/|\\S*?[?&]v=)|youtu\\.be\\/)([a-zA-Z0-9_-]{11})"

--- a/client/src/Room.elm
+++ b/client/src/Room.elm
@@ -126,15 +126,18 @@ update msg model =
 
         ( Loaded { inputText, room, roomID }, SetVideo ) ->
             let
+                videoID =
+                    Player.youtubeIdFromUrl inputText |> Maybe.withDefault ""
+
                 newModel =
                     model
                         |> updateModelInputText ""
-                        |> updateModelRoom { room | currentVideoID = inputText }
+                        |> updateModelRoom { room | currentVideoID = videoID }
 
                 cmds =
                     Cmd.batch
-                        [ sendPlayerMessage (Player.LoadVideo inputText 0)
-                        , sendData (encode roomID (SetCurrentVideo inputText))
+                        [ sendPlayerMessage (Player.LoadVideo videoID 0)
+                        , sendData (encode roomID (SetCurrentVideo videoID))
                         ]
             in
             ( newModel, cmds )
@@ -194,7 +197,7 @@ view model =
                         [ h3 [] [ text room.inputText ]
                         , input
                             [ type_ "text"
-                            , placeholder "Video ID"
+                            , placeholder "Cole aqui o link do vídeo que deseja assistir"
                             , onInput TextChanged
                             , value room.inputText
                             ]


### PR DESCRIPTION
I still should make a treatment when the URL coudn't find a match, but for now it's
ok

closes #12