### PR TITLE
Add playlist feature

### DIFF
--- a/client/src/main.css
+++ b/client/src/main.css
@@ -15,7 +15,6 @@ html * {
 	-webkit-tap-highlight-color: transparent;
 }
 
-
 body {
   margin: 0;
   text-align: center;
@@ -35,7 +34,7 @@ h2 {
 
 img {
   margin: 20px 0;
-  max-width: 200px;
+  max-width: 100px;
 }
 
 .button {
@@ -55,19 +54,67 @@ button:hover {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	width: 100%;
+  height: 100vh;
+}
+
+.content__wrapper {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	padding: 20px;
+}
+
+
+.divider {
+	width: 2px;
+	box-shadow: 0.05em 0.05em 0 #2cfcfd,
+	-0.05em 0 0 #ff0aff,
+	0.09em 0 0 #ffff0a;
+	background: #000;
+	margin: 10px 0;
+}
+
+.playlist {
+	flex-grow: 1;
+	margin: 0 20px;
+  border-width: 0 0 3px 0;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+}
+
+.playlist__list {
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+
+.playlist__title {
+	text-shadow:  0.05em 0.05em 0 #2cfcfd,
+	-0.05em 0 0 #ff0aff,
+	0.09em 0 0 #ffff0a;
+	font-size: 1.3em;
+	margin-bottom: 10px;
+}
+.playlist__current_item {
+	text-shadow:  0.05em 0.05em 0 #2cfcfd,
+	-0.05em 0 0 #ff0aff,
+	0.09em 0 0 #ffff0a;
+}
+
+.player__wrapper {
+	flex-grow: 2;
 }
 
 .video-url {
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
+	justify-content: center;
 	width: 100%;
-	align-items: center;
 }
-
-.video_url__button {
-	font-size: 30px;
-}
-
 
 .video-url__group {
   position: relative;


### PR DESCRIPTION
Now we store a list of videoID to represent a playlist that will be
played in order (for now) and the current video index to keep track
which video is being played.

Based on the event AddVideo we append the new video ID to the list and
broadcast the message to other clients on the room. For
now, we're just not adding it when the URL for the video is invalid. We
will give a proper message on the field on the future

Once the video has ended, we change the current video index or do
nothing if the index is not found on the current playlist.

Closes #16