### PR TITLE
Fix concurrency issue by not using youtube's control

### DIFF
--- a/client/src/ControlButton.elm
+++ b/client/src/ControlButton.elm
@@ -1,0 +1,32 @@
+module ControlButton exposing (pauseButtonView, playButtonView)
+
+import Html exposing (div)
+import Html.Attributes as HTMLAtt
+import Svg exposing (g, svg)
+import Svg.Attributes exposing (..)
+
+
+pauseButtonView =
+    div [ HTMLAtt.class "control-button__wrapper" ]
+        [ svg [ viewBox "0 0 19.106 19.461" ] [ g [ transform "translate(-70.58 -135.26)" ] [ Svg.path [ d "m71.479 136.16v17.662h5.9852v-17.662h-5.9852zm11.324 0v17.662h5.9852v-17.662h-5.9852z", stroke "#000", strokeLinejoin "round", strokeWidth "1.7971" ] [] ] ]
+        ]
+
+
+playButtonView =
+    div [ HTMLAtt.class "control-button__wrapper" ]
+        [ svg
+            [ viewBox "0 0 19.106 19.461"
+            ]
+            [ g
+                [ transform "translate(-70.58 -135.26)"
+                ]
+                [ Svg.path
+                    [ d "m71.637 136.26-0.0569 17.461 17.106-8.5926z"
+                    , stroke "#000"
+                    , strokeLinejoin "round"
+                    , strokeWidth "2"
+                    ]
+                    []
+                ]
+            ]
+        ]

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -15,7 +15,6 @@ var app = Elm.Main.init({
 serviceWorker.unregister();
 
 
-console.log('teste', process.env);
 var socket = io(process.env.ELM_APP_SOCKET_ADDRESS);
 
 app.ports.sendData.subscribe(function(message) {
@@ -39,13 +38,12 @@ let player = null;
 
 app.ports.emitPlayerMsg.subscribe( ({message, data}) =>  {
   if(!player) {
-    player = YouTubePlayer('player', { playerVars: { 'autoplay': 0 }});
+    player = YouTubePlayer('player', { playerVars: { 'autoplay': 0, 'controls': 0 }});
     player.on('stateChange', ({ data }) => {
       app.ports.playerMsgReceiver.send(stateNames[data] || "");
     });
   }
 
-  console.log('emitPlayer', message, data)
   switch(message) {
     case 'play':
         player.playVideo();

--- a/client/src/main.css
+++ b/client/src/main.css
@@ -107,8 +107,21 @@ button:hover {
 
 .player__wrapper {
   flex-grow: 2;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
+.control-button__wrapper {
+	width: 20px;
+	margin: 5px;
+}
+
+.control-button__wrapper:hover svg {
+  filter:  drop-shadow(0.15em 0.15em 0 #2cfcfd)
+	drop-shadow(-0.15em 0 0 #ff0aff)
+	drop-shadow(0.19em 0 0 #ffff0a);
+}
 .video-url {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
If an user click pause / play too fast, all the other users start a
infinity loop because we're listening to the players events and sending
them at the same time.

So while playing, receives a pause, the player emits playing, then I
send it and so on...

This way I have more control on when play/stop and avoid the player
ending up sending messages to itself

closes #21 